### PR TITLE
Fix: add `type: "module"` to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "astro-vanjs",
 	"version": "0.1.1",
+	"type": "module",
 	"description": "Astro integration for VanJS",
 	"scripts": {
 		"prepublish": "pnpm run build",


### PR DESCRIPTION
This fixes a dev error in Astro running the VanJS integration